### PR TITLE
Improve WebApiBaseClient tests.

### DIFF
--- a/tests/Bitai.WebApi.Helpers.Tests/WebApiBaseClientTests.cs
+++ b/tests/Bitai.WebApi.Helpers.Tests/WebApiBaseClientTests.cs
@@ -6,6 +6,8 @@ namespace Bitai.WebApi.Helpers.Tests;
 
 public class WebApiBaseClientTests
 {
+    #region Constructor Tests
+
     [Fact]
     public void Constructor_WhenBaseUrlIsNullOrEmpty_ThrowsArgumentNullException()
     {
@@ -20,6 +22,73 @@ public class WebApiBaseClientTests
 
         Assert.Contains("cannot end with the character '/'", exception.Message);
     }
+
+    [Fact]
+    public void Constructor_WithBaseUrl_SetsBaseUrlProperty()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+
+        Assert.Equal("https://api.example.com", client.TestBaseUrl);
+    }
+
+    [Fact]
+    public void Constructor_WithBaseUrlAndHandler_SetsHandlerAndDisposeHandler()
+    {
+        using var handler = new HttpClientHandler();
+        var client = new TestWebApiBaseClient("https://api.example.com", handler, disposeHandler: true);
+
+        Assert.Same(handler, client.TestHandler);
+        Assert.True(client.TestDisposeHandler);
+        Assert.Equal("https://api.example.com", client.TestBaseUrl);
+    }
+
+    [Fact]
+    public void Constructor_WithBaseUrlAndCredential_SetsCredential()
+    {
+        var credential = new WebApiClientCredential
+        {
+            AuthorityUrl = "https://auth.example.com",
+            ApiScope = "api.scope",
+            ClientId = "client-id",
+            ClientSecret = "client-secret"
+        };
+        var client = new TestWebApiBaseClient("https://api.example.com", credential);
+
+        Assert.Same(credential, client.TestCredential);
+        Assert.Equal("https://api.example.com", client.TestBaseUrl);
+    }
+
+    [Fact]
+    public void Constructor_WithBaseUrlCredentialAndHandler_SetsAllProperties()
+    {
+        using var handler = new HttpClientHandler();
+        var credential = new WebApiClientCredential
+        {
+            AuthorityUrl = "https://auth.example.com",
+            ApiScope = "api.scope",
+            ClientId = "client-id",
+            ClientSecret = "client-secret"
+        };
+        var client = new TestWebApiBaseClient("https://api.example.com", credential, handler, disposeHandler: false);
+
+        Assert.Same(credential, client.TestCredential);
+        Assert.Same(handler, client.TestHandler);
+        Assert.False(client.TestDisposeHandler);
+        Assert.Equal("https://api.example.com", client.TestBaseUrl);
+    }
+
+    [Fact]
+    public void Constructor_WithNullHandler_AllowsCreation()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com", handler: null!, disposeHandler: false);
+
+        Assert.Null(client.TestHandler);
+        Assert.False(client.TestDisposeHandler);
+    }
+
+    #endregion
+
+    #region Exception Handling Tests
 
     [Fact]
     public void GetClientRequestException_WhenResponseIsNotSuccessful_ReturnsExceptionWithResponse()
@@ -68,6 +137,41 @@ public class WebApiBaseClientTests
 
         Assert.Same(response, exception.NoSuccessResponse);
     }
+
+    [Fact]
+    public void ThrowClientRequestException_WithDifferentHttpStatusCodes_ThrowsWebApiRequestException()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+        var statusCodes = new[]
+        {
+            HttpStatusCode.Unauthorized,
+            HttpStatusCode.Forbidden,
+            HttpStatusCode.NotFound,
+            HttpStatusCode.MethodNotAllowed,
+            HttpStatusCode.Conflict,
+            HttpStatusCode.GatewayTimeout
+        };
+
+        foreach (var statusCode in statusCodes)
+        {
+            var response = new NoSuccessResponseWithEmptyContent(
+                statusCode,
+                statusCode.ToString(),
+                "Kestrel",
+                "Fri, 05 Jun 2026 12:00:00 GMT");
+
+            var exception = Assert.Throws<WebApiRequestException>(
+                () => client.ThrowClientRequestException($"Request failed with {statusCode}.", response));
+
+            Assert.Equal($"Request failed with {statusCode}.", exception.Message);
+            Assert.Same(response, exception.NoSuccessResponse);
+            Assert.Equal(statusCode, exception.NoSuccessResponse.HttpStatusCode);
+        }
+    }
+
+    #endregion
+
+    #region DTO Response Tests
 
     [Fact]
     public void GetDTOFromResponse_WhenResponseContainsDto_ReturnsContent()
@@ -132,6 +236,66 @@ public class WebApiBaseClientTests
 
         Assert.Same(dtos, result);
     }
+
+    [Fact]
+    public void GetDTOFromResponse_WithComplexObject_ReturnsDeserializedContent()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+        var dto = new ComplexDto
+        {
+            Id = 1,
+            Name = "test",
+            Values = new[] { "a", "b", "c" },
+            Metadata = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } }
+        };
+        var response = new SuccessResponseWithJsonContent<ComplexDto>
+        {
+            HttpStatusCode = HttpStatusCode.OK,
+            Content = dto
+        };
+
+        var result = client.GetDTOFromResponse<ComplexDto>(response);
+
+        Assert.Equal(dto.Id, result.Id);
+        Assert.Equal(dto.Name, result.Name);
+        Assert.Equal(dto.Values, result.Values);
+        Assert.Equal(dto.Metadata, result.Metadata);
+    }
+
+    [Fact]
+    public async Task GetDTOFromResponseAsync_WithNullContent_ReturnsNull()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+        var response = new SuccessResponseWithJsonContent<string>
+        {
+            HttpStatusCode = HttpStatusCode.OK,
+            Content = null!
+        };
+
+        var result = await client.GetDTOFromResponseAsync<string>(response);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetEnumerableDTOFromResponse_WithEmptyCollection_ReturnsEmptyEnumerable()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+        var emptyDtos = Enumerable.Empty<SampleDto>();
+        var response = new SuccessResponseWithJsonContent<IEnumerable<SampleDto>>
+        {
+            HttpStatusCode = HttpStatusCode.OK,
+            Content = emptyDtos
+        };
+
+        var result = client.GetEnumerableDTOFromResponse<SampleDto>(response);
+
+        Assert.Empty(result);
+    }
+
+    #endregion
+
+    #region CreateHttpClient Tests
 
     [Fact]
     public async Task CreateHttpClient_WhenAuthorizationIsRequestedWithoutCredential_ThrowsInvalidOperationException()
@@ -200,6 +364,52 @@ public class WebApiBaseClientTests
     }
 
     [Fact]
+    public async Task CreateHttpClient_WithNullHandler_CreatesHttpClient()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+
+        using var httpClient = await client.CreateHttpClientForTest();
+
+        Assert.NotNull(httpClient);
+        Assert.Equal(TimeSpan.FromMinutes(3), httpClient.Timeout);
+    }
+
+    [Fact]
+    public async Task CreateHttpClient_WithCustomHandler_CreatesHttpClientWithHandler()
+    {
+        using var handler = new HttpClientHandler();
+        var client = new TestWebApiBaseClient("https://api.example.com", handler, disposeHandler: false);
+
+        using var httpClient = await client.CreateHttpClientForTest();
+
+        Assert.NotNull(httpClient);
+    }
+
+    [Fact]
+    public async Task CreateHttpClient_ClearsDefaultRequestHeaders()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+
+        using var httpClient = await client.CreateHttpClientForTest();
+
+        // All headers except Accept should be cleared
+        Assert.DoesNotContain(httpClient.DefaultRequestHeaders, h => h.Key != "Accept");
+    }
+
+    [Fact]
+    public async Task CreateHttpClient_WithAuthorization_WhenCredentialIsNull_ThrowsInvalidOperationException()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await client.CreateHttpClientForTest(setAuthorizationHeaderWithBearerToken: true));
+    }
+
+    #endregion
+
+    #region GetStringContentFromObject Tests
+
+    [Fact]
     public async Task GetStringContentFromObject_WhenDtoIsProvided_SerializesAsUtf8Json()
     {
         var client = new TestWebApiBaseClient("https://api.example.com");
@@ -214,12 +424,183 @@ public class WebApiBaseClientTests
     }
 
     [Fact]
+    public async Task GetStringContentFromObject_WithNullObject_SerializesAsNullJson()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+
+        using var content = client.GetStringContentFromObjectForTest(null!);
+        var json = await content.ReadAsStringAsync();
+
+        Assert.Equal("null", json);
+        Assert.Equal("application/json", content.Headers.ContentType?.MediaType, true);
+    }
+
+    [Fact]
+    public async Task GetStringContentFromObject_WithStringValue_SerializesAsString()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+
+        using var content = client.GetStringContentFromObjectForTest("test string");
+        var json = await content.ReadAsStringAsync();
+
+        Assert.Equal("\"test string\"", json);
+    }
+
+    [Fact]
+    public async Task GetStringContentFromObject_WithCollection_SerializesAsJsonArray()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+        var items = new[] { new SampleDto(1, "one"), new SampleDto(2, "two") };
+
+        using var content = client.GetStringContentFromObjectForTest(items);
+        var json = await content.ReadAsStringAsync();
+
+        Assert.Contains("\"Id\":1", json, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"Id\":2", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetStringContentFromObject_WithInvalidEncoding_ThrowsNotImplementedException()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+        var dto = new SampleDto(1, "test");
+
+        Assert.Throws<NotImplementedException>(() => client.GetStringContentFromObjectForTest(dto, (Content_Encoding)999));
+    }
+
+    [Fact]
+    public void GetStringContentFromObject_WithInvalidMediaType_ThrowsNotImplementedException()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+        var dto = new SampleDto(1, "test");
+
+        Assert.Throws<NotImplementedException>(() => client.GetStringContentFromObjectForTest(dto, Content_Encoding.UTF8, (Content_MediaType)999));
+    }
+
+    [Fact]
+    public async Task GetStringContentFromObject_WithDefaultParameters_UsesUtf8AndApplicationJson()
+    {
+        var client = new TestWebApiBaseClient("https://api.example.com");
+        var dto = new SampleDto(1, "test");
+
+        using var content = client.GetStringContentFromObjectForTest(dto);
+
+        Assert.Equal("utf-8", content.Headers.ContentType?.CharSet, true);
+        Assert.Equal("application/json", content.Headers.ContentType?.MediaType, true);
+    }
+
+    #endregion
+
+    #region WebApiClientParameters Tests
+
+    [Fact]
     public void WebApiClientParameters_WhenRead_ExposeDefaultValues()
     {
         Assert.Equal(180, WebApiBaseClient.WebApiClientParameters.ClientRequestTimeOut);
         Assert.Equal(1 * 1024 * 1024, WebApiBaseClient.WebApiClientParameters.MaxResponseContentBufferSize);
         Assert.True(WebApiBaseClient.WebApiClientParameters.SerializerOptions.PropertyNameCaseInsensitive);
     }
+
+    [Fact]
+    public void WebApiClientParameters_WhenModified_AppliesNewValues()
+    {
+        var originalTimeout = WebApiBaseClient.WebApiClientParameters.ClientRequestTimeOut;
+        var originalBufferSize = WebApiBaseClient.WebApiClientParameters.MaxResponseContentBufferSize;
+
+        try
+        {
+            WebApiBaseClient.WebApiClientParameters.ClientRequestTimeOut = 60;
+            WebApiBaseClient.WebApiClientParameters.MaxResponseContentBufferSize = 512 * 1024;
+
+            Assert.Equal(60, WebApiBaseClient.WebApiClientParameters.ClientRequestTimeOut);
+            Assert.Equal(512 * 1024, WebApiBaseClient.WebApiClientParameters.MaxResponseContentBufferSize);
+        }
+        finally
+        {
+            WebApiBaseClient.WebApiClientParameters.ClientRequestTimeOut = originalTimeout;
+            WebApiBaseClient.WebApiClientParameters.MaxResponseContentBufferSize = originalBufferSize;
+        }
+    }
+
+    [Fact]
+    public void WebApiClientParameters_SerializerOptions_CanBeModified()
+    {
+        var originalOptions = WebApiBaseClient.WebApiClientParameters.SerializerOptions;
+
+        try
+        {
+            var newOptions = new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = false,
+                WriteIndented = true
+            };
+            WebApiBaseClient.WebApiClientParameters.SerializerOptions = newOptions;
+
+            Assert.False(WebApiBaseClient.WebApiClientParameters.SerializerOptions.PropertyNameCaseInsensitive);
+            Assert.True(WebApiBaseClient.WebApiClientParameters.SerializerOptions.WriteIndented);
+        }
+        finally
+        {
+            WebApiBaseClient.WebApiClientParameters.SerializerOptions = originalOptions;
+        }
+    }
+
+    #endregion
+
+    #region WebApiClientCredential Tests
+
+    [Fact]
+    public void WebApiClientCredential_WhenCreated_AllPropertiesAreNullable()
+    {
+        var credential = new WebApiClientCredential();
+
+        Assert.Null(credential.AuthorityUrl);
+        Assert.Null(credential.ApiScope);
+        Assert.Null(credential.ClientId);
+        Assert.Null(credential.ClientSecret);
+    }
+
+    [Fact]
+    public void WebApiClientCredential_WhenSet_StoresAllProperties()
+    {
+        var credential = new WebApiClientCredential
+        {
+            AuthorityUrl = "https://auth.example.com",
+            ApiScope = "api.read",
+            ClientId = "my-client",
+            ClientSecret = "my-secret"
+        };
+
+        Assert.Equal("https://auth.example.com", credential.AuthorityUrl);
+        Assert.Equal("api.read", credential.ApiScope);
+        Assert.Equal("my-client", credential.ClientId);
+        Assert.Equal("my-secret", credential.ClientSecret);
+    }
+
+    [Fact]
+    public async Task CreateHttpClient_WithCredential_SetupForAuthorization_DoesNotThrow()
+    {
+        var credential = new WebApiClientCredential
+        {
+            AuthorityUrl = "https://auth.example.com",
+            ApiScope = "api.read",
+            ClientId = "my-client",
+            ClientSecret = "my-secret"
+        };
+        var client = new TestWebApiBaseClient("https://api.example.com", credential);
+
+        // This will throw because we can't actually connect to the auth server,
+        // but it proves the credential setup is correct for authorization flow
+        var exception = await Record.ExceptionAsync(async () =>
+            await client.CreateHttpClientForTest(setAuthorizationHeaderWithBearerToken: true));
+
+        // The exception should NOT be about missing credential
+        Assert.DoesNotContain(nameof(WebApiBaseClient.ClientCredential), exception?.Message ?? string.Empty);
+    }
+
+    #endregion
+
+    #region Helper Classes
 
     private sealed class TestWebApiBaseClient : WebApiBaseClient
     {
@@ -228,16 +609,49 @@ public class WebApiBaseClientTests
         {
         }
 
+        public TestWebApiBaseClient(string webApiBaseUrl, HttpClientHandler handler, bool disposeHandler)
+            : base(webApiBaseUrl, handler, disposeHandler)
+        {
+        }
+
+        public TestWebApiBaseClient(string webApiBaseUrl, WebApiClientCredential clientCredentials)
+            : base(webApiBaseUrl, clientCredentials)
+        {
+        }
+
+        public TestWebApiBaseClient(string webApiBaseUrl, WebApiClientCredential clientCredentials, HttpClientHandler handler, bool disposeHandler)
+            : base(webApiBaseUrl, clientCredentials, handler, disposeHandler)
+        {
+        }
+
+        public string TestBaseUrl => WebApiBaseUrl;
+
+        public HttpClientHandler TestHandler => Handler;
+
+        public bool TestDisposeHandler => DisposeHandler;
+
+        public WebApiClientCredential TestCredential => ClientCredential;
+
         public Task<AuthorizedHttpClient> CreateHttpClientForTest(bool setAuthorizationHeaderWithBearerToken = false)
         {
             return CreateHttpClient(setAuthorizationHeaderWithBearerToken);
         }
 
-        public StringContent GetStringContentFromObjectForTest(object dto)
+        public StringContent GetStringContentFromObjectForTest(object dto, Content_Encoding encoding = Content_Encoding.UTF8, Content_MediaType mediaType = Content_MediaType.ApplicationJson)
         {
-            return GetStringContentFromObject(dto);
+            return GetStringContentFromObject(dto, encoding, mediaType);
         }
     }
 
     private sealed record SampleDto(int Id, string Name);
+
+    private sealed class ComplexDto
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public string[]? Values { get; set; }
+        public Dictionary<string, string>? Metadata { get; set; }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary by Sourcery

Expand test coverage and helper infrastructure for WebApiBaseClient and its related configuration and credential types.

Enhancements:
- Extend the internal TestWebApiBaseClient helper to support additional constructor overloads and expose internal properties and methods for testing, including DTO serialization helpers and new DTO types.

Tests:
- Add constructor tests to verify WebApiBaseClient initialization paths with base URL, handlers, and credentials, including null handler scenarios.
- Extend exception handling tests to validate WebApiRequestException creation across multiple HTTP status codes.
- Broaden DTO response tests to cover complex objects, null content, and empty collections for both sync and async methods.
- Add CreateHttpClient tests for null and custom handlers, header clearing behavior, and authorization behavior with and without credentials.
- Expand GetStringContentFromObject tests to cover nulls, strings, collections, default parameters, and invalid encoding/media type branches.
- Add WebApiClientParameters tests to verify default values and the ability to modify client settings and serializer options.
- Add WebApiClientCredential tests to confirm property nullability, proper storage, and use in authorization setup flows.